### PR TITLE
Multivalued parameters should be separated by commas

### DIFF
--- a/veracross_api/veracross.py
+++ b/veracross_api/veracross.py
@@ -82,7 +82,7 @@ class Veracross(object):
             self.set_auth()
 
             if parameters is not None:
-                s = self.api_url + source + ".json?" + parse.urlencode(parameters, safe=':-')
+                s = self.api_url + source + ".json?" + parse.urlencode(parameters, safe=':-,')
             else:
                 s = self.api_url + source + ".json"
 


### PR DESCRIPTION
Per the API v2's [documentation](https://api.veracross.com/docs/v2#overview) (scroll to "Usage"), to pass a list of values to a single parameter, you need to use a comma in the URL. They were being encoded from `,` to `%2C`.

An example use case is  `people.json?roles=1,2,3`). 1 is student, 2 is former student, 3 is Alumnus/a.